### PR TITLE
Add in reproducible results via DigitalOcean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+/contrib/out/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,3 @@ log = "0.4.11"
 pretty_env_logger = "0.4.0"
 tokio = { version = "0.2.22", features = ["macros"] }
 hyper = "0.13.7"
-
-[profile.release]
-debug = true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,29 @@ time target/release/rjbench http://localhost:8000 $roomid:server.name
 This will go through the play defined in romeo_and_juliet.txt and create users
 for each character and sends one /send request for each line they say.
 
+### Reproducible runs
+
+While [contrib](contrib/README.md) contains some rudimentary documentation, to be able to use it, you must first:
+ - Have `ansible-playbook` installed
+ - Have a DigitalOcean account (with billing info registered, or using a budget)
+ - Have one of your public keys added to digitalocean (it's also important that your local machine tries to log into servers with this automatically)
+ - Install the `ansible-galaxy` collections documented in [contrib's readme](contrib/README.md)
+ - Add the DigitalOcean API token to your environment (also as documented in [contrib's readme](contrib/README.md))
+
+Then, `cd` into `contrib/`, and run
+```
+ansible-playbook digitalocean_playbook.yml
+```
+
+This'll run the tests in parallel on digitalocean droplets, results will be put into `contrib/out/`,
+you can adjust which server versions or revisions are ran/built using `contrib/group_vars/server.yml`,
+the committed file is "known to work", and can always be rolled back to when something goes wrong.
+
+Some stages of the playbook could take a while, such as building `rjbench`, or `conduit`, or the testing itself.
+It's advised to leave it alone when it does this, although, if a stage takes more than an hour (as a rule of thumb),
+or if you're curious what's happening, take one of the IP addresses noted during the "Create droplets" stage, do `ssh root@IP_ADDRESS`,
+and look around with `htop` and `journalctl -f -n 100`.
+
 ## Results (2020-08-19):
 
 Synapse:

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,12 @@
+`digitalocean_playbook.yml` needs ansible-galaxy module `community.digitalocean`, general roles need `community.docker`, install with;
+
+```
+ansible-galaxy collection install community.docker community.digitalocean
+```
+
+Add a `DO_API_TOKEN` with a digitalocean `write` API token to your environment variables before running the playbook.
+
+Note: Due to the way digitalocean charges you for droplets,
+each droplet will be minimally charged for one cent,
+meaning you'll have to pay `droplets * 0.01` cents for each run of the playbook,
+with however many droplets you have created and destroyed during the run.

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -6,6 +6,8 @@ ansible-galaxy collection install community.docker community.digitalocean
 
 Add a `DO_API_TOKEN` with a digitalocean `write` API token to your environment variables before running the playbook.
 
+Parameters can be adjusted in `group_vars/servers.yml`
+
 Note: Due to the way digitalocean charges you for droplets,
 each droplet will be minimally charged for one cent,
 meaning you'll have to pay `droplets * 0.01` cents for each run of the playbook,

--- a/contrib/ansible.cfg
+++ b/contrib/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+# too annoying and holds up the playbook each time, we're already creating the hosts, no need to hold up over them
+host_key_checking = False
+
+[ssh_connection]
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=5 -o ServerAliveCountMax=4

--- a/contrib/digitalocean_playbook.yml
+++ b/contrib/digitalocean_playbook.yml
@@ -1,0 +1,116 @@
+- name: Prepare out/ dir
+  hosts: localhost
+  tasks:
+    - name: Make out/ dir
+      file:
+        path: "{{ playbook_dir }}/out"
+        state: directory
+
+- name: Create droplets
+  hosts: localhost
+  vars:
+    droplet_size: s-2vcpu-2gb
+    droplet_region: ams3
+    droplet_image: ubuntu-20-04-x64
+    # TODO add other roles
+    roles:
+      - "synapse-sqlite"
+      # - "synapse-postgres"
+      # - "dendrite-sqlite"
+      # - "dendrite-postgres"
+      - "conduit"
+  debugger: on_failed
+  tasks:
+    - name: Get digitalocean API keys
+      digital_ocean_sshkey_info: {}
+      register: ssh_keys_raw
+
+    - name: Create DO droplets
+      include_tasks: tasks/create_droplet.yml
+
+      loop: "{{ roles }}"
+
+- name: Mkdirs
+  hosts: servers
+  tasks:
+    - name: Mkdirs
+      include_tasks: "{{ playbook_dir }}/tasks/mkdirs.yml"
+
+## BUILDING RJBENCH
+
+# Takes too long, uncomment (and comment local build + install) if you encounter problems with glibc and the like
+- name: Install rjbench remotely
+  hosts: servers
+  tasks:
+    - name: Install rjbench command
+      include_tasks: tasks/install_rjbench_remote.yml
+
+# - name: Build rjbench locally
+#   hosts: localhost
+#   tasks:
+#     - name: Build rjbench
+#       include_tasks: tasks/build_rjbench_locally.yml
+
+# - name: Install rjbench from local
+#   hosts: servers
+#   tasks:
+#     - name: Install rjbench from local
+#       copy:
+#         src: "{{ playbook_dir }}/../target/release/rjbench"
+#         dest: "/rjbench/app"
+#         mode: "777"
+#     - name: Copy script
+#       copy:
+#         src: "{{ playbook_dir }}/../romeo_and_juliet.txt"
+#         dest: /rjbench/app
+
+# ## SETTING UP SERVER
+# # has to happen after rjbench or else OOM could occur, or the build could be extremely slow
+
+- name: Include setup
+  tags:
+    - setup
+  import_playbook: generic_playbook.yml
+
+# ## RUNNING RJBENCH
+
+- name: Run test
+  hosts: servers
+  tags:
+     - run
+  debugger: on_failed
+  tasks:
+    - name: Run timing...
+      shell:
+        cmd: time /rjbench/app/rjbench http://localhost:8080
+        chdir: /rjbench/app
+        executable: /bin/bash
+      register: time_cmd
+
+    - name: Copy timing output to local file
+      copy:
+        content: "{{ time_cmd.stderr }}"
+        dest: "out/{{ rjbench_role }}.txt"
+      delegate_to: localhost
+
+## CLEANUP
+
+- name: Destroy all droplets
+  hosts: localhost
+  tags:
+     - delete
+  vars:
+    roles:
+      - "synapse-sqlite"
+      - "synapse-postgres"
+      - "dendrite-sqlite"
+      - "dendrite-postgres"
+      - "conduit"
+  tasks:
+    - name: Remove droplets
+      digital_ocean_droplet:
+        name: "rjbench-{{ item }}-throwaway"
+        state: absent
+        unique_name: yes
+
+      loop: "{{ roles }}"

--- a/contrib/generic_playbook.yml
+++ b/contrib/generic_playbook.yml
@@ -1,0 +1,22 @@
+# boilerplate :(
+- name: Run roles
+  hosts: servers
+  debugger: on_failed
+  strategy: free
+  tasks:
+  - include_role:
+      name: synapse_sqlite
+    when: "'synapse-sqlite' in group_names"
+  - include_role:
+      name: synapse_postgres
+    when: "'synapse-postgres' in group_names"
+  - include_role:
+      name: dendrite_sqlite
+    when: "'dendrite-sqlite' in group_names"
+  - include_role:
+      name: dendrite_postgres
+    when: "'dendrite-postgres' in group_names"
+  - include_role:
+      name: conduit
+    when: "'conduit' in group_names"
+# boilerplate over :)

--- a/contrib/group_vars/servers.yml
+++ b/contrib/group_vars/servers.yml
@@ -1,0 +1,4 @@
+synapse_image: matrixdotorg/synapse:v1.29.0
+
+conduit_url: https://gitlab.com/famedly/conduit
+conduit_hash: 6538d91567abf64afe6c56f7726541e573138b48

--- a/contrib/roles/conduit/files/conduit.service
+++ b/contrib/roles/conduit/files/conduit.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Conduit Matrix homeserver
+After=network.target
+
+[Service]
+Type=simple
+
+Environment="ROCKET_ENV=production"
+Environment="ROCKET_DATABASE_PATH=/rjbench/server"
+Environment="CONDUIT_CONFIG=/rjbench/server/conduit.toml"
+
+ExecStart=/root/.cargo/bin/conduit
+Restart=on-failure
+RestartSec=10
+StartLimitInterval=1m
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/roles/conduit/files/conduit.toml
+++ b/contrib/roles/conduit/files/conduit.toml
@@ -1,0 +1,9 @@
+[global]
+server_name = "localhost:8080"
+database_path = "/rjbench/server/conduit_db"
+port = 8080
+max_request_size = 20_000_000 # in bytes
+allow_registration = true
+allow_encryption = true
+allow_federation = false
+address = "127.0.0.1"

--- a/contrib/roles/conduit/tasks/main.yml
+++ b/contrib/roles/conduit/tasks/main.yml
@@ -1,0 +1,30 @@
+- name: Install cargo and build dependencies
+  apt:
+    name:
+      - cargo
+      - libssl-dev
+      - pkg-config
+    state: latest
+    update_cache: yes
+
+- name: Build conduit-bin (this can take a while)
+  debugger: on_failed
+  shell:
+    cmd: cargo install --git {{conduit_url}} --rev {{conduit_hash}} --locked
+    creates: /root/.cargo/bin/conduit
+
+- name: Install service file
+  copy:
+    src: conduit.service
+    dest: /etc/systemd/system
+
+- name: Install config file
+  copy:
+    src: conduit.toml
+    dest: /rjbench/server
+
+- name: Start conduit service
+  systemd:
+    name: conduit
+    state: started
+    daemon_reload: yes

--- a/contrib/roles/dendrite_postgres/tasks/main.yml
+++ b/contrib/roles/dendrite_postgres/tasks/main.yml
@@ -1,0 +1,4 @@
+# TODO: Hash out
+- name: Marker
+  debug:
+    msg: "Dendrite Postgres hasn't been hashed out yet, NOOP"

--- a/contrib/roles/dendrite_sqlite/tasks/main.yml
+++ b/contrib/roles/dendrite_sqlite/tasks/main.yml
@@ -1,0 +1,4 @@
+# TODO: Hash out
+- name: Marker
+  debug:
+    msg: "Dendrite Sqlite hasn't been hashed out yet, NOOP"

--- a/contrib/roles/synapse_postgres/tasks/main.yml
+++ b/contrib/roles/synapse_postgres/tasks/main.yml
@@ -1,0 +1,4 @@
+# TODO: Hash out
+- name: Marker
+  debug:
+    msg: "Synapse Postgres hasn't been hashed out yet, NOOP"

--- a/contrib/roles/synapse_sqlite/files/homeserver.override.yaml
+++ b/contrib/roles/synapse_sqlite/files/homeserver.override.yaml
@@ -1,0 +1,30 @@
+listeners:
+  - port: 8008
+    tls: false
+    type: http
+    bind_addresses: ['0.0.0.0']
+
+    resources:
+      - names: [client]
+        compress: false
+
+enable_registration: true
+
+rc_message:
+ per_second: 9001
+ burst_count: 9001
+
+rc_registration:
+ per_second: 9001
+ burst_count: 9001
+
+rc_login:
+ address:
+   per_second: 9001
+   burst_count: 9001
+ account:
+   per_second: 9001
+   burst_count: 9001
+ failed_attempts:
+   per_second: 9001
+   burst_count: 9001

--- a/contrib/roles/synapse_sqlite/tasks/main.yml
+++ b/contrib/roles/synapse_sqlite/tasks/main.yml
@@ -1,0 +1,52 @@
+- name: Install Docker
+  include_tasks: "{{playbook_dir}}/tasks/install_docker.yml"
+
+- name: Pull synapse docker image
+  docker_image:
+    name: "{{ synapse_image }}"
+    source: pull
+
+- name: Generate synapse default config
+  docker_container:
+    container_default_behavior: compatibility
+    name: "synapse-generate"
+    image: "{{ synapse_image }}"
+    command: "generate"
+    state: started
+    detach: no
+    volumes:
+      - "/rjbench/server:/data"
+    env:
+      SYNAPSE_SERVER_NAME: "localhost:8080"
+      SYNAPSE_REPORT_STATS: "no"
+  register: generate_container
+
+# - name: Debug container output
+#   debug:
+#     msg: "{{ generate_container.container.Output }}"
+
+- name: Copy Override Config
+  copy:
+    src: homeserver.override.yaml
+    dest: /rjbench/server
+
+- name: Start Synapse
+  docker_container:
+    container_default_behavior: compatibility
+    name: "synapse"
+    image: "{{ synapse_image }}"
+    state: started
+    volumes:
+      - "/rjbench/server:/data"
+    ports:
+      - "127.0.0.1:8080:8008"
+    command: "run --config-path=/data/homeserver.yaml --config-path=/data/homeserver.override.yaml"
+
+- name: Wait for synapse to come up
+  uri:
+    url: "http://127.0.0.1:8080/_matrix/client/versions"
+    status_code: 200
+  register: result
+  until: result.status == 200
+  retries: 60
+  delay: 1

--- a/contrib/tasks/build_rjbench_locally.yml
+++ b/contrib/tasks/build_rjbench_locally.yml
@@ -1,0 +1,6 @@
+- name: Build rjbench
+  debugger: on_failed
+  shell:
+    cmd: cargo build --release --locked
+    chdir: "{{ playbook_dir }}/../"
+    creates: "{{ playbook_dir }}/../target/release/rjbench"

--- a/contrib/tasks/create_droplet.yml
+++ b/contrib/tasks/create_droplet.yml
@@ -1,0 +1,32 @@
+---
+- name: Create droplet for {{ item }}
+  digital_ocean_droplet:
+    name: "rjbench-{{ item }}-throwaway"
+    size: "{{ droplet_size }}"
+    region: "{{ droplet_region }}"
+    image: "{{ droplet_image }}"
+    wait_timeout: 600
+    state: present
+    unique_name: yes
+    ssh_keys: "{{ ssh_keys_raw.data | map(attribute='fingerprint') }}"
+  register: this_droplet
+
+- name: Add new droplet to host group
+  add_host:
+    hostname: "{{ this_droplet.data.ip_address }}"
+    groups:
+      - "{{ item }}"
+      - servers
+    ansible_user: root
+    rjbench_role: "{{ item }}"
+
+- name: Wait for SSH to come up
+  wait_for:
+    host: "{{ this_droplet.data.ip_address }}"
+    port: 22
+    timeout: 320
+    state: started
+
+- name: Print info about this_droplet
+  debug:
+    msg: "ID is {{ this_droplet.data.droplet.id }}. IP is {{ this_droplet.data.ip_address }}."

--- a/contrib/tasks/install_docker.yml
+++ b/contrib/tasks/install_docker.yml
@@ -1,0 +1,34 @@
+- name: Install required system packages
+  apt:
+    name:
+      [
+        "apt-transport-https",
+        "ca-certificates",
+        "curl",
+        "software-properties-common",
+        "python3-pip",
+        "virtualenv",
+        "python3-setuptools",
+      ]
+    state: latest
+    update_cache: yes
+
+- name: Add Docker GPG apt Key
+  apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    state: present
+
+- name: Add Docker Repository
+  apt_repository:
+    repo: deb https://download.docker.com/linux/ubuntu bionic stable
+    state: present
+
+- name: Update apt and install docker-ce
+  apt:
+    name: docker-ce
+    state: latest
+    update_cache: yes
+
+- name: Install Docker Module for Python
+  pip:
+    name: docker

--- a/contrib/tasks/install_rjbench_remote.yml
+++ b/contrib/tasks/install_rjbench_remote.yml
@@ -1,0 +1,31 @@
+- name: Copy to remote
+  copy:
+    src: "{{ playbook_dir }}/../{{ item }}"
+    dest: /rjbench/app
+  loop:
+    - src
+    - Cargo.toml
+    - Cargo.lock
+    - romeo_and_juliet.txt
+
+- name: Install cargo and build dependencies
+  apt:
+    name:
+      - cargo
+      - libssl-dev
+      - pkg-config
+    state: latest
+    update_cache: yes
+
+- name: Build rjbench
+  debugger: on_failed
+  shell:
+    cmd: cargo build --release --locked
+    chdir: /rjbench/app
+    creates: /rjbench/app/target/release/rjbench
+
+- name: Create symbolic link
+  ansible.builtin.file:
+    src: /rjbench/app/target/release/rjbench
+    dest: /rjbench/app/rjbench
+    state: link

--- a/contrib/tasks/mkdirs.yml
+++ b/contrib/tasks/mkdirs.yml
@@ -1,0 +1,9 @@
+- name: Create directories
+  file:
+    path: "/rjbench{{ item }}"
+    state: directory
+    mode: '0755'
+  loop:
+   - ""
+   - /server
+   - /app


### PR DESCRIPTION
This adds `synapse-sqlite` and `conduit` to the list of reproducible results, `synapse-postgres` and both `dendrite-*` targets need to be added later on.